### PR TITLE
Fix signature that leads to Fatal error

### DIFF
--- a/Translation/DatabaseFreshResource.php
+++ b/Translation/DatabaseFreshResource.php
@@ -43,7 +43,7 @@ class DatabaseFreshResource implements SelfCheckingResourceInterface
     /**
      * {@inheritdoc}
      */
-    public function isFresh($timestamp): bool
+    public function isFresh(int $timestamp): bool
     {
         return true; // Consider a resource comming from the database is always fresh
     }


### PR DESCRIPTION
PHP Fatal error:  Declaration of Lexik\Bundle\TranslationBundle\Translation\DatabaseFreshResource::isFresh($timestamp) must be compatible with Symfony\Component\Config\Resource\SelfCheckingResourceInterface::isFresh(int $timestamp): bool in xxx\vendor\lexik\translation-bundle\Translation\DatabaseFreshResource.php on line 46

See https://github.com/symfony/config/blob/5.4/Resource/SelfCheckingResourceInterface.php