### PR TITLE
Fix deprecations

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -19,7 +19,7 @@ class Configuration implements ConfigurationInterface
      * (non-PHPdoc)
      * @see \Symfony\Component\Config\Definition.ConfigurationInterface::getConfigTreeBuilder()
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('lexik_translation');
         $rootNode = $treeBuilder->getRootNode();


### PR DESCRIPTION
1x: Method "Symfony\Component\Config\Definition\ConfigurationInterface::getConfigTreeBuilder()" might add "TreeBuilder" as a native return type declaration in the future. Do the same in implementation "Lexik\Bundle\TranslationBundle\DependencyInjection\Configuration" now to avoid errors or add an explicit @return annotation to suppress this message.